### PR TITLE
Clean css

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
     <label for="addressRange" id="rangelabel">Select Address Range In Miles</label>
     <!-- This is the  distance-slider-->
       <form id="range-select">
-        <input type="range" list="tickmarks" value="25" class="custom-range" id="addressRange" min="1" max="50" step="1" oninput="this.nextElementSibling.value = this.value">
-        <output id="rangeSelection">25</output>
+        <input type="range" list="tickmarks" value="1" class="custom-range" id="addressRange" min="1" max="50" step="1" oninput="this.nextElementSibling.value = this.value">
+        <output id="rangeSelection">1</output>
       </form>
       <!-- These are the radios for the location parameters; the value is relayed to the relevant JS code.. -->
       <div class="list-group list-group-horizontal w-50 m-auto">

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
           Parks
         </label>
         <label class="list-group-item flex-fill">
-          <input class="form-check-input me-1" type="radio" name ="paramRadios" id="radioRestaurants" value="restaurant">
+          <input class="form-check-input me-1 just" type="radio" name ="paramRadios" id="radioRestaurants" value="restaurant">
           Restaurants
         </label>
         <label class="list-group-item flex-fill">
@@ -61,8 +61,6 @@
           Gas Stations
         </label>
         <button class = "refresh-button" type="submit" onClick="refreshPage()">Refresh Search</button>
-
-
       </div>
     
 
@@ -85,7 +83,7 @@
 
 
   <footer class="d-flex p-2 align-items-end">
-    <a href="https://cloud.google.com/maps-platform/terms/">Legal Jargon Hotspot(Google TOS)</a>
+    <a href="https://cloud.google.com/maps-platform/terms/">Legal Jargon Hotspot (Google TOS)</a>
   </footer>
 
 <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>

--- a/media/.~lock.Project-1.pptx#
+++ b/media/.~lock.Project-1.pptx#
@@ -1,0 +1,1 @@
+Zachariah Schneider,DESKTOP-9BLU840/Zac's General PC,DESKTOP-9BLU840,02.10.2022 13:20,file:///C:/Users/Zammin/AppData/Roaming/OpenOffice/4;

--- a/style.css
+++ b/style.css
@@ -11,6 +11,12 @@
 	justify-content: center;
 }
 
+#addressRange {
+	width: 54%;
+	margin-left: 25%;
+
+}
+
 #showMap {
 	margin-left: 50px;
 	border-top: 3px solid black;
@@ -37,12 +43,25 @@
 	border-radius: 3px;
 	margin-top: 25px;
 }
-
-
-
+/* This controls the location of the footer. */
 footer {
 	margin-top: 120px;
+	margin-left: 35%;
+	margin-right: 35%;
+	margin-bottom: 3%;
   }
+/* This makes the footer text white with a black shadow */
+footer a:link, footer a:visited {
+	color: white;
+	font-size: x-large;
+	text-shadow: 2px 1px black;
+}
+/* This makes the range selectors black with a white shadow. */
+#rangelabel, #rangeSelection {
+		color: black;
+		font-size: x-large;
+		text-shadow: 2px 1px white;
+}
 
   body {
 	background-image: url(media/green-lawn-with-trees-and-silhouettes-buildings-vector-20903030.jpeg);
@@ -52,11 +71,34 @@ footer {
 	height: 100%;
 	background-blend-mode:darken;
   }
-
+/* Lines 75-103 control the size and style of the results sidebar. */
  #sidebar {
 	background-color: rgb(243, 237, 237);
+	border: 3px dashed black;
+	margin-top: 25px;
+	text-align: center;
+	margin-right:2%;
+ }
 
+ #more {
+	margin-bottom: 2%;
+ }
 
+ ul {
+	display: inline-block;
+	height: fit-content;
+	width: 400px;
+	border-radius: 3px;
+	margin-bottom: 2%;
+	list-style: none;
+	padding-left: 0;
+	font-size: large;
+	text-align: left;
+ }
+
+ li:hover {
+	color: rosybrown;
+	cursor: pointer;
  }
 
  .list-group {
@@ -70,3 +112,20 @@ footer {
     text-decoration: wavy;
     display: flexbox;
  } 
+
+ @media screen and (max-width: 700px) {
+	#map, ul{
+		width: 200px;
+		width: 200px;
+	}
+
+	ul {
+		height: fit-content;
+	}
+	.list-group-horizontal {
+		margin: auto;
+		display: flex;
+		flex-direction: column;
+		flex-wrap: wrap;
+	}
+ }


### PR DESCRIPTION
This change introduces minor HTML and significant CSS changes to the page.

The page has updated text-shadows and sizes to the range labels and the Footer content, and the range slider has both an adjusted width and a new default value of, "1". The radio box is also now media-flexible. 

The most significant changes are to the Results sidebar, which now has styling to better match the map. The map and the results bar are media-flexible, and the length of the results sidebar matches the length of the list contained within. Hovering over items in the results list will now cause the result to change color and the cursor will change to a pointer hand, to indicate to users that the list items are interactive.



![cleanCSS scrnshot 1](https://user-images.githubusercontent.com/108361033/193471787-73058a72-ef30-4037-8c46-5845d71adefa.JPG)
![cleanCSS scrnshot 2](https://user-images.githubusercontent.com/108361033/193471788-9120da6d-eba7-4f25-9443-41de1cbd41a8.JPG)
![cleanCSS scrnshot 3](https://user-images.githubusercontent.com/108361033/193471786-fc33ffc6-7188-4837-a9d5-8c33a76533fb.JPG)
